### PR TITLE
Add fastbook pip packages to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,8 +14,10 @@ dependencies:
 - fastprogress>=0.1.22
 - pillow
 - python>=3.6
-- pip
 - scikit-learn
 - scipy
 - spacy
-
+- pip
+- pip:
+  - graphviz
+  - fastbook


### PR DESCRIPTION
This change makes the new environment.yml work out of the box with the fastbook .

It also fixes issues like "Missing `graphviz` - please run `conda install fastbook`"
It also makes environment using ```conda env create --file environment.yml``` work out of the box for the first notebook.